### PR TITLE
Drop import of removed IHP.Controller.Context module

### DIFF
--- a/IHP/Zip/ControllerFunctions.hs
+++ b/IHP/Zip/ControllerFunctions.hs
@@ -4,7 +4,6 @@ module IHP.Zip.ControllerFunctions
 ) where
 
 import IHP.Prelude
-import IHP.Controller.Context
 import IHP.ControllerSupport
 import Network.Wai
 import Network.HTTP.Types


### PR DESCRIPTION
## Summary

Required by [digitallyinduced/ihp#2633](https://github.com/digitallyinduced/ihp/pull/2633), which deletes the `IHP.Controller.Context` module. `ControllerContext` is now a type alias re-exported from `IHP.ControllerSupport` (already imported here), so removing the dead import is enough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)