### PR TITLE
Bump base upper bound to < 4.23

### DIFF
--- a/ihp-zip.cabal
+++ b/ihp-zip.cabal
@@ -23,7 +23,7 @@ source-repository head
 library
     default-language: GHC2021
     build-depends:
-          base        >= 4.17 && < 4.22
+          base        >= 4.17 && < 4.23
         , ihp         >= 1.5  && < 2
         , zip-archive >= 0.4  && < 0.5
         , wai         >= 3.2  && < 3.3


### PR DESCRIPTION
GHC 9.14 ships base-4.22. Bump the upper bound to allow building with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)