### PR TITLE
Fix ambiguous `hContentDisposition` (http-types clash); bump to 0.1.2

### DIFF
--- a/IHP/Zip/ControllerFunctions.hs
+++ b/IHP/Zip/ControllerFunctions.hs
@@ -60,5 +60,3 @@ renderZipUnnamed archive = respondAndExit $ responseLBS status200 headers (archi
 
         headers :: ResponseHeaders
         headers = [ contentType, contentDisposition ]
-
-hContentDisposition = "Content-Disposition"

--- a/ihp-zip.cabal
+++ b/ihp-zip.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.2
 name:                ihp-zip
-version:             0.1.1
+version:             0.1.2
 synopsis:            Support for making ZIP archives with IHP
 description:         Provides the @renderZip@ / @renderZipUnnamed@ controller
                      helpers for streaming a @Codec.Archive.Zip.Archive@


### PR DESCRIPTION
## Problem

`ihp-zip` 0.1.1 fails to compile under GHC 9.12 / current Stackage nightlies:

```
IHP/Zip/ControllerFunctions.hs:34:31: error: [GHC-87543]
    Ambiguous occurrence ‘hContentDisposition’.
    It could refer to
       either ‘Network.HTTP.Types.hContentDisposition’ (imported from Network.HTTP.Types)
           or ‘IHP.Zip.ControllerFunctions.hContentDisposition’ (defined at line 64)
```

Newer **http-types** (≥ 0.12.x) now exports `hContentDisposition`, which collides with the identical local binding this module defined for itself before http-types provided it.

## Fix

Drop the redundant local `hContentDisposition = "Content-Disposition"` definition. The two use sites now resolve to `Network.HTTP.Types.hContentDisposition`, whose value is the same `"Content-Disposition"` — so behavior is unchanged. Version bumped `0.1.1` → `0.1.2`.

## Verification

Built against **GHC 9.12.5-rc2 + ihp 1.5.0** (aarch64-darwin) with this change applied — `IHP.Zip.ControllerFunctions` compiles and the library installs cleanly. The unpatched source fails at exactly lines 34 and 59.

## Follow-up

After releasing **0.1.2** to Hackage, IHP can update its `NixSupport/hackage/ihp-zip.nix` pin and drop the temporary `postPatch` workaround added in [ihp#2729](https://github.com/digitallyinduced/ihp/pull/2729).

🤖 Generated with [Claude Code](https://claude.com/claude-code)